### PR TITLE
fix invalid spanish characters

### DIFF
--- a/lib/i18n/es.json
+++ b/lib/i18n/es.json
@@ -19,7 +19,7 @@
     "13": "trece",
     "14": "catorce",
     "15": "quince",
-    "16": "diecis閕s",
+    "16": "diecis茅is",
     "17": "diecisiete",
     "18": "dieciocho",
     "19": "diecinueve",
@@ -65,63 +65,63 @@
       "avoidPrefixException": [1]
     },
     {
-      "singular": "mill髇",
+      "singular": "mill贸n",
       "plural": "millones"
     },
     {
-      "singular": "bill髇",
+      "singular": "bill贸n",
       "plural": "billones"
     },
     {
-      "singular": "trill髇",
+      "singular": "trill贸n",
       "plural": "trillones"
     },
     {
-      "singular": "cuatrill髇",
+      "singular": "cuatrill贸n",
       "plural": "cuatrillones"
     },
     {
-      "singular": "quintill髇",
+      "singular": "quintill贸n",
       "plural": "quintillones"
     },
     {
-      "singular": "sextill髇",
+      "singular": "sextill贸n",
       "plural": "sextillones"
     },
     {
-      "singular": "septill髇",
+      "singular": "septill贸n",
       "plural": "septillones"
     },
     {
-      "singular": "octill髇",
+      "singular": "octill贸n",
       "plural": "octillones"
     },
     {
-      "singular": "nonill髇",
+      "singular": "nonill贸n",
       "plural": "nonillones"
     },
     {
-      "singular": "decill髇",
+      "singular": "decill贸n",
       "plural": "decillones"
     },
     {
-      "singular": "undecill髇",
+      "singular": "undecill贸n",
       "plural": "undecillones"
     },
     {
-      "singular": "duodecill髇",
+      "singular": "duodecill贸n",
       "plural": "duodecillones"
     },
     {
-      "singular": "tredecill髇",
+      "singular": "tredecill贸n",
       "plural": "tredecillones"
     },
     {
-      "singular": "cuatrodecill髇",
+      "singular": "cuatrodecill贸n",
       "plural": "cuatrodecillones"
     },
     {
-      "singular": "quindecill髇",
+      "singular": "quindecill贸n",
       "plural": "quindecillones"
     }
   ]

--- a/lib/i18n/pt.json
+++ b/lib/i18n/pt.json
@@ -6,7 +6,7 @@
     "0": "zero",
     "1": "um",
     "2": "dois",
-    "3": "trÍs",
+    "3": "tr√™s",
     "4": "quatro",
     "5": "cinco",
     "6": "seis",
@@ -61,56 +61,56 @@
       "andException": true
     },
     {
-      "singular": "milh„o",
-      "plural": "milhıes"
+      "singular": "milh√£o",
+      "plural": "milh√µes"
     },
     {
-      "singular": "bilh„o",
-      "plural": "bilhıes"
+      "singular": "bilh√£o",
+      "plural": "bilh√µes"
     },
     {
-      "singular": "trilh„o",
-      "plural": "trilhıes"
+      "singular": "trilh√£o",
+      "plural": "trilh√µes"
     },
     {
-      "singular": "quadrilh„o",
-      "plural": "quadrilh„o"
+      "singular": "quadrilh√£o",
+      "plural": "quadrilh√£o"
     },
     {
-      "singular": "quintilh„o",
-      "plural": "quintilhıes"
+      "singular": "quintilh√£o",
+      "plural": "quintilh√µes"
     },
     {
-      "singular": "sextilh„o",
-      "plural": "sextilhıes"
+      "singular": "sextilh√£o",
+      "plural": "sextilh√µes"
     },
     {
-      "singular": "septilh„o",
-      "plural": "septilhıes"
+      "singular": "septilh√£o",
+      "plural": "septilh√µes"
     },
     {
-      "singular": "octilh„o",
-      "plural": "octilhıes"
+      "singular": "octilh√£o",
+      "plural": "octilh√µes"
     },
     {
-      "singular": "nonilh„o",
-      "plural": "nonilhıes"
+      "singular": "nonilh√£o",
+      "plural": "nonilh√µes"
     },
     {
-      "singular": "decilh„o",
-      "plural": "decilhıes"
+      "singular": "decilh√£o",
+      "plural": "decilh√µes"
     },
     {
-      "singular": "undecilh„o",
-      "plural": "undecilhıes"
+      "singular": "undecilh√£o",
+      "plural": "undecilh√µes"
     },
     {
-      "singular": "doudecilh„o",
-      "plural": "doudecilhıes"
+      "singular": "doudecilh√£o",
+      "plural": "doudecilh√µes"
     },
     {
-      "singular": "tredecilh„o",
-      "plural": "tredecilhıes"
+      "singular": "tredecilh√£o",
+      "plural": "tredecilh√µes"
     }
   ]
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -83,6 +83,7 @@ describe('written-number', function() {
 
     it('correctly converts numbers < 20', function() {
       writtenNumber(13).should.equal('trece');
+      writtenNumber(16).should.equal('diecis√©is');
       writtenNumber(19).should.equal('diecinueve');
     });
 
@@ -109,7 +110,7 @@ describe('written-number', function() {
         'cuatro millones trescientos veintitres mil cincuenta y cinco'
       );
       writtenNumber(1570025).should.equal(
-        'un millÛn quinientos setenta mil veinticinco'
+        'un mill√≥n quinientos setenta mil veinticinco'
       );
     });
 
@@ -118,7 +119,7 @@ describe('written-number', function() {
       writtenNumber(2580000000).should.equal(
         'dos mil quinientos ochenta millones'
       );
-      writtenNumber(1000000000000).should.equal('un billÛn');
+      writtenNumber(1000000000000).should.equal('un bill√≥n');
       writtenNumber(3627000000000).should.equal(
         'tres billones seiscientos veintisiete mil millones'
       );
@@ -136,7 +137,7 @@ describe('written-number', function() {
     });
 
     it('correctly converts numbers < 10', function() {
-      writtenNumber(3).should.equal('trÍs');
+      writtenNumber(3).should.equal('tr√™s');
       writtenNumber(8).should.equal('oito');
     });
 
@@ -149,41 +150,41 @@ describe('written-number', function() {
       writtenNumber(20).should.equal('vinte');
       writtenNumber(25).should.equal('vinte e cinco');
       writtenNumber(88).should.equal('oitenta e oito');
-      writtenNumber(73).should.equal('setenta e trÍs');
+      writtenNumber(73).should.equal('setenta e tr√™s');
     });
 
     it('correctly converts numbers < 1000', function() {
       writtenNumber(144).should.equal('cento e quarenta e quatro');
       writtenNumber(200).should.equal('duzentos');
       writtenNumber(1234).should.equal('mil duzentos e trinta e quatro');
-      writtenNumber(4323).should.equal('quatro mil trezentos e vinte e trÍs');
+      writtenNumber(4323).should.equal('quatro mil trezentos e vinte e tr√™s');
       writtenNumber(242).should.equal('duzentos e quarenta e dois');
     });
 
     it('correctly converts numbers > 1000', function() {
       writtenNumber(4323000).should.equal(
-        'quatro milhıes trezentos e vinte e trÍs mil'
+        'quatro milh√µes trezentos e vinte e tr√™s mil'
       );
       writtenNumber(4323055).should.equal(
-        'quatro milhıes trezentos e vinte e trÍs mil e cinquenta e cinco'
+        'quatro milh√µes trezentos e vinte e tr√™s mil e cinquenta e cinco'
       );
       writtenNumber(1570025).should.equal(
-        'um milh„o quinhentos e setenta mil e vinte e cinco'
+        'um milh√£o quinhentos e setenta mil e vinte e cinco'
       );
     });
 
     it('correctly converts numbers > 1 000 000 000', function() {
-      writtenNumber(1000000000).should.equal('um bilh„o');
+      writtenNumber(1000000000).should.equal('um bilh√£o');
       writtenNumber(2580000000).should.equal(
-        'dois bilhıes quinhentos e oitenta milhıes'
+        'dois bilh√µes quinhentos e oitenta milh√µes'
       );
-      writtenNumber(1000000000000000).should.equal('um quadrilh„o');
+      writtenNumber(1000000000000000).should.equal('um quadrilh√£o');
       writtenNumber(3627000000000).should.equal(
-        'trÍs trilhıes seiscentos e vinte e sete bilhıes'
+        'tr√™s trilh√µes seiscentos e vinte e sete bilh√µes'
       );
     });
   });
-  
+
   describe('writtenNumber(n, { lang: \'fr\', ... })', function() {
     before(function() {
       writtenNumber.defaults.lang = 'fr';


### PR DESCRIPTION
OS: OSX Yosemite
Node: 4.4.2

i'm using this code:

```js
'use strict';

var writtenNumber = require('written-number');

writtenNumber.defaults.lang = 'es';

getText('16');

function getText(number) {
  var x = writtenNumber(number);

  console.log(x);
}
```

but the result is: -> diecis�is, as you can see there is an encoding issue.

demo:

![written-number-issue](https://cloud.githubusercontent.com/assets/4262050/14406658/9dc1153c-fe73-11e5-833b-5663557dbce8.gif)

i've updated the `es.json` file and now it works correctly

![written-number-result](https://cloud.githubusercontent.com/assets/4262050/14406697/1ed8bde0-fe75-11e5-823b-ca393fc45b6c.gif)
