### PR TITLE
bug/72 fixed hundred numbers without trailing numbers for Spanish

### DIFF
--- a/lib/i18n/es.json
+++ b/lib/i18n/es.json
@@ -72,7 +72,8 @@
     {
       "singular": "ciento",
       "useBaseInstead": true,
-      "useBaseException": [1]
+      "useBaseException": [1],
+      "useBaseExceptionWhenNoTrailingNumbers": true
     },
     {
       "singular": "mil",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -137,6 +137,7 @@ describe("written-number", function () {
       writtenNumber(1234).should.equal("mil doscientos treinta y cuatro");
       writtenNumber(4323).should.equal("cuatro mil trescientos veintitrés");
       writtenNumber(242).should.equal("doscientos cuarenta y dos");
+      writtenNumber(2100).should.equal("dos mil cien");
     });
 
     it("correctly converts numbers > 1000", function () {


### PR DESCRIPTION
Pull request to fix issue #72 Incorrect written number for hundred numbers without trailing numbers in Spanish

- Added "useBaseExceptionWhenNoTrailingNumbers" to es.json config file
- Added test to verify new behavior